### PR TITLE
Remove depend tag not needed

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,8 +16,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>mimick</depend>
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
   <description>
     Wrapper around mimick, it provides an ExternalProject build of mimick.
   </description>
-  <maintainer email="TODO@todo.com">TBD</maintainer>
+  <maintainer email="jjperez@ekumenlabs.com">Jorge J. Perez</maintainer>
   <license>Apache License 2.0</license>  <!-- the contents of this package are Apache 2.0 -->
   <license>MIT</license>  <!-- mimick is MIT -->
 

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>mimick_vendor</name>
-  <version>0.0.1</version>
+  <version>0.0.0</version>
   <description>
     Wrapper around mimick, it provides an ExternalProject build of mimick.
   </description>


### PR DESCRIPTION
Addresses this regression: http://build.ros2.org/view/Rci/job/Rci__nightly-debug_ubuntu_focal_amd64/23/

Caused by https://github.com/ros2/ros2/pull/985

`mimick` is not a valid `rosdep`, and not needed in the vendor package.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>