### PR TITLE
Avoid CMAKE_BUILD_TYPE warnings on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ macro(build_mimick)
   endif()
 
   if(DEFINED CMAKE_BUILD_TYPE)
-    if (WIN32)
+    if(WIN32)
       build_command(_build_command CONFIGURATION ${CMAKE_BUILD_TYPE})
       list(APPEND cmake_commands "BUILD_COMMAND ${_build_command}")
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,44 +6,55 @@ find_package(ament_cmake REQUIRED)
 
 macro(build_mimick)
 
-  set(extra_cmake_args)
+  set(cmake_commands)
+  set(cmake_configure_args -Wno-dev)
+  set(cmake_configure_args -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install)
+
   if(WIN32)
+    if(DEFINED CMAKE_GENERATOR)
+      list(APPEND cmake_configure_args -G ${CMAKE_GENERATOR})
+    endif()
     if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "^(x86_|x86-|AMD|amd|x)64$")
-      list(APPEND extra_cmake_args -A x64)
+      list(APPEND cmake_configure_args -A x64)
     endif()
   endif()
 
   if(DEFINED CMAKE_BUILD_TYPE)
-    list(APPEND extra_cmake_args -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+    if (WIN32)
+      build_command(_build_command CONFIGURATION ${CMAKE_BUILD_TYPE})
+      list(APPEND cmake_commands "BUILD_COMMAND ${_build_command}")
+    else()
+      list(APPEND cmake_configure_args -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+    endif()
   endif()
 
   if(DEFINED CMAKE_TOOLCHAIN_FILE)
-    list(APPEND extra_cmake_args "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
+    list(APPEND cmake_configure_args "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
     if(ANDROID)
       if(DEFINED ANDROID_ABI)
-        list(APPEND extra_cmake_args "-DANDROID_ABI=${ANDROID_ABI}")
+        list(APPEND cmake_configure_args "-DANDROID_ABI=${ANDROID_ABI}")
       endif()
       if(DEFINED ANDROID_CPP_FEATURES)
-        list(APPEND extra_cmake_args "-DANDROID_CPP_FEATURES=${ANDROID_CPP_FEATURES}")
+        list(APPEND cmake_configure_args "-DANDROID_CPP_FEATURES=${ANDROID_CPP_FEATURES}")
       endif()
       if(DEFINED ANDROID_FUNCTION_LEVEL_LINKING)
-        list(APPEND extra_cmake_args "-DANDROID_FUNCTION_LEVEL_LINKING=${ANDROID_FUNCTION_LEVEL_LINKING}")
+        list(APPEND cmake_configure_args "-DANDROID_FUNCTION_LEVEL_LINKING=${ANDROID_FUNCTION_LEVEL_LINKING}")
       endif()
       if(DEFINED ANDROID_NATIVE_API_LEVEL)
-        list(APPEND extra_cmake_args "-DANDROID_NATIVE_API_LEVEL=${ANDROID_NATIVE_API_LEVEL}")
+        list(APPEND cmake_configure_args "-DANDROID_NATIVE_API_LEVEL=${ANDROID_NATIVE_API_LEVEL}")
       endif()
       if(DEFINED ANDROID_NDK)
-        list(APPEND extra_cmake_args "-DANDROID_NDK=${ANDROID_NDK}")
+        list(APPEND cmake_configure_args "-DANDROID_NDK=${ANDROID_NDK}")
       endif()
       if(DEFINED ANDROID_STL)
-        list(APPEND extra_cmake_args "-DANDROID_STL=${ANDROID_STL}")
+        list(APPEND cmake_configure_args "-DANDROID_STL=${ANDROID_STL}")
       endif()
       if(DEFINED ANDROID_TOOLCHAIN_NAME)
-        list(APPEND extra_cmake_args "-DANDROID_TOOLCHAIN_NAME=${ANDROID_TOOLCHAIN_NAME}")
+        list(APPEND cmake_configure_args "-DANDROID_TOOLCHAIN_NAME=${ANDROID_TOOLCHAIN_NAME}")
       endif()
     endif()
   else()
-    list(APPEND extra_cmake_args "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
+    list(APPEND cmake_configure_args "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
   endif()
 
   include(ExternalProject)
@@ -51,9 +62,9 @@ macro(build_mimick)
     GIT_REPOSITORY https://github.com/hidmic/Mimick
     GIT_TAG hidmic/cxx-compatibility
     TIMEOUT 6000
+    ${cmake_commands}
     CMAKE_ARGS
-      -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
-      ${extra_cmake_args}
+      ${cmake_configure_args}
   )
 
   # The external project will install to the build folder, but we'll install that on make install.


### PR DESCRIPTION
Fixes https://ci.ros2.org/view/nightly/job/nightly_win_rel/1639/msbuild/ Introduced with https://github.com/ros2/ros2/pull/985#issuecomment-663610669

Signed-off-by: Michel Hidalgo <michel@ekumenlabs.com>