### PR TITLE
Also export include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ endmacro()
 
 build_mimick()
 
+ament_export_include_directories(include)
 ament_export_libraries(mimick)
 ament_export_dependencies(mimick)
 


### PR DESCRIPTION
This will let other packages include mimick headers without having to explicitly target mimick itself (instead ament_target_dependencies mimick_vendor).

I'm not sure if "include" is the right thing to put inside of the `ament_export_include_directories` call. I think it could also reference `${CMAKE_INSTALL_PREFIX}` since that's where the install directory of mimick is installed.

Signed-off-by: Stephen Brawner <brawner@gmail.com>