### PR TITLE
Update tag for armv7l support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ macro(build_mimick)
   include(ExternalProject)
   externalproject_add(mimick-ext
     GIT_REPOSITORY https://github.com/ros2/Mimick.git
-    GIT_TAG 99a35f3d2067708931945c64ac9caee80a0ef50e
+    GIT_TAG f171450b5ebaa3d2538c762a059dfc6ab7a01039
     TIMEOUT 6000
     ${cmake_commands}
     CMAKE_ARGS


### PR DESCRIPTION
Precisely what the title says. Connected to https://github.com/ros2/Mimick/pull/16.

CI up to `rclcpp`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13367)](http://ci.ros2.org/job/ci_linux/13367/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8294)](http://ci.ros2.org/job/ci_linux-aarch64/8294/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11096)](http://ci.ros2.org/job/ci_osx/11096/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13420)](http://ci.ros2.org/job/ci_windows/13420/)
