### PR TITLE
Add missing build tool dependency on 'git'

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <author email="jjperez@ekumenlabs.com">Jorge J. Perez</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
This package uses Git to fetch sources during the build phase:
https://github.com/ros2/mimick_vendor/blob/2136d97c1d036edc638260578fa15e8b8835ca5b/CMakeLists.txt#L61-L68

Here is the backing rosdep key:
https://github.com/ros/rosdistro/blob/dba8ecd3562b487e477425cc695586f604dbe9af/rosdep/base.yaml#L1170-L1181