### PR TITLE
Suppress update of pinned git repository

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,13 @@ macro(build_mimick)
   endif()
 
   include(ExternalProject)
-  externalproject_add(mimick-ext
+  set(mimick_version "f171450b5ebaa3d2538c762a059dfc6ab7a01039")
+  externalproject_add(mimick-${mimick_version}
     GIT_REPOSITORY https://github.com/ros2/Mimick.git
-    GIT_TAG f171450b5ebaa3d2538c762a059dfc6ab7a01039
+    GIT_TAG ${mimick_version}
+    GIT_CONFIG advice.detachedHead=false
+    # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
+    UPDATE_COMMAND ""
     TIMEOUT 6000
     ${cmake_commands}
     CMAKE_ARGS


### PR DESCRIPTION
The source at that ref will never change, so there is no need to try to update it. This will avoid unnecessary invalidation of the build and install targets for the external project.

This is the same issue we're working around in ament/uncrustify_vendor#22.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13576)](http://ci.ros2.org/job/ci_linux/13576/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8467)](http://ci.ros2.org/job/ci_linux-aarch64/8467/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11297)](http://ci.ros2.org/job/ci_osx/11297/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13639)](http://ci.ros2.org/job/ci_windows/13639/)