### PR TITLE
Don't overwrite -Wno-dev CMake argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ macro(build_mimick)
 
   set(cmake_commands)
   set(cmake_configure_args -Wno-dev)
-  set(cmake_configure_args -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install)
+  list(APPEND cmake_configure_args -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install)
 
   if(WIN32)
     if(DEFINED CMAKE_GENERATOR)


### PR DESCRIPTION
Not sure this is actually needed, but it certainly isn't working without this fix.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13575)](http://ci.ros2.org/job/ci_linux/13575/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8466)](http://ci.ros2.org/job/ci_linux-aarch64/8466/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11296)](http://ci.ros2.org/job/ci_osx/11296/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13638)](http://ci.ros2.org/job/ci_windows/13638/)