### PR TITLE
Don't build the samples or tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,9 @@ macro(build_mimick)
     ${cmake_commands}
     CMAKE_ARGS
       ${cmake_configure_args}
+    PATCH_COMMAND
+      sed -i "s/add_subdirectory \(test\)/ /g" CMakeLists.txt &&
+      sed -i "s/add_subdirectory \(sample\)/ /g" CMakeLists.txt
   )
 
   # The external project will install to the build folder, but we'll install that on make install.


### PR DESCRIPTION
The tests were breaking under my Nix build:

```
mimick_vendor> [ 86%] Building CXX object test/CMakeFiles/mmk_test_cxx.dir/test.cpp.o
mimick_vendor> In file included from /nix/store/hyz46mc9bnjl6rq6hzbwjaybjybzav8c-glibc-2.35-163-dev/include/errno.h:25,
mimick_vendor>                  from /build/build/mimick_vendor/mimick-de11f8377eb95f932a03707b583bf3d4ce5bd3e7-prefix/src/mimick-de11f8377eb95f932a03707b583bf3d4ce5bd3e7/include/mimick/mock.h:27,
mimick_vendor>                  from /build/build/mimick_vendor/mimick-de11f8377eb95f932a03707b583bf3d4ce5bd3e7-prefix/src/mimick-de11f8377eb95f932a03707b583bf3d4ce5bd3e7/include/mimick/mimick.h:401,
mimick_vendor>                  from /build/build/mimick_vendor/mimick-de11f8377eb95f932a03707b583bf3d4ce5bd3e7-prefix/src/mimick-de11f8377eb95f932a03707b583bf3d4ce5bd3e7/sample/strdup/test.c:1:
mimick_vendor> /nix/store/hyz46mc9bnjl6rq6hzbwjaybjybzav8c-glibc-2.35-163-dev/include/features.h:412:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wcpp-Werror=cpp8;;]
mimick_vendor>   412 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
mimick_vendor>       |    ^~~~~~~
```

Easiest fix seemed to be to just turn them off.