### PR TITLE
Update to the commit that fixes the executable stack.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 
 ament_vendor(mimick_vendor
   VCS_URL https://github.com/ros2/Mimick.git
-  VCS_VERSION e300cc88ed828e41ee8548b489bc0b64b2b6436e
+  VCS_VERSION 6b08fa3fb91e490a8131903e4ea2480019854698
 )
 
 ament_export_dependencies(mimick)


### PR DESCRIPTION
See https://github.com/ros2/Mimick/pull/26 for more information.

Still a draft since I need to test out the aarch64 changes in CI.