### PR TITLE
Update to the commit that fixes mmk_noreturn.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
 ament_vendor(mimick_vendor
-  VCS_URL https://github.com/christophebedard/Mimick.git
-  VCS_VERSION 12ab16f1e1e81b9f14171ff8b4e331caebf135ff
+  VCS_URL https://github.com/ros2/Mimick.git
+  VCS_VERSION 60f8e4f7d4714231cbfabe8e0cdda251b38bf5d4
 )
 
 ament_export_dependencies(mimick)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
 ament_vendor(mimick_vendor
-  VCS_URL https://github.com/ros2/Mimick.git
-  VCS_VERSION 8d17528528167707ae38e1c6803a1e6a5845b01d
+  VCS_URL https://github.com/christophebedard/Mimick.git
+  VCS_VERSION 12ab16f1e1e81b9f14171ff8b4e331caebf135ff
 )
 
 ament_export_dependencies(mimick)


### PR DESCRIPTION
This goes along with https://github.com/ros2/Mimick/pull/29 .  Note that we'll have to update both the URL and the VERSION once we merge in the other PR; this is here for CI purposes.

@christophebedard FYI.